### PR TITLE
ci: restore macOS caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,6 @@ jobs:
 
       # Optional step:
       - name: Cache clojure dependencies
-        # TODO: remove next line after working again
-        #  temporarily work around https://github.com/actions/runner-images/issues/13341
-        #  by disabling caching for macOS
-        if: ${{ runner.os != 'macOS' }}
         uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
GitHub seems to have fixed their macOS runners

See: https://github.com/actions/runner-images/issues/13341#issuecomment-3572431071